### PR TITLE
Add Azerothian Archives reputation and Undead/Night Elf heritage armor

### DIFF
--- a/reputations/09_dragonflight.yml
+++ b/reputations/09_dragonflight.yml
@@ -2,6 +2,12 @@ name: "Dragonflight"
 minimumLevel: 60
 reputations:
 
+# 10.2.5
+-
+  - both:
+      id: 2615 # Azerothian Archives
+      icon: "achievement/19685" # Tenured Archivist
+
 # 10.2
 -
   - both:

--- a/transmog/misc/racial.yml
+++ b/transmog/misc/racial.yml
@@ -167,6 +167,7 @@ groups:
   - Orc 2
   - Orc 3
   - Tauren
+  - Undead
   - Blood Elf
   - Goblin
   - Nightborne
@@ -233,6 +234,21 @@ groups:
         9:  39918 # Wrists
         10: 39914 # Hands
         16: 40741 # Back
+
+    # description=0 (Horde)
+    - name: Heritage of the Forsaken
+      wowheadSetId:
+      items:
+        1:  81999 82000 # Head
+        3:  81983 # Shoulders
+        5:  81984 82812 # Chest
+        6:  81985 # Waist
+        7:  81986 # Legs
+        8:  81987 # Feet
+        9:  81988 # Wrists
+        10: 81989 # Hands
+        16: 81998 # Back
+        19: 82561 82562 # Tabard
 
     # description=0 set=1804
     - name: Heritage of the Sin'dorei

--- a/transmog/misc/racial.yml
+++ b/transmog/misc/racial.yml
@@ -9,6 +9,7 @@ groups:
   - Human 3
   - Dwarf
   - Gnome
+  - Night Elf
   - Worgen
   - Void Elf
   - Lightforged Draenei
@@ -82,6 +83,19 @@ groups:
         9:  39926 # Wrists
         10: 39922 # Hands
         16: 39927 # Back
+
+    # description=0 (Alliance)
+    - name: Heritage of the Kaldorei
+      wowheadSetId:
+      items:
+        1:  82569 # Head
+        3:  82571 # Shoulders
+        5:  82573 # Chest
+        6:  82572 # Waist
+        7:  82567 # Legs
+        8:  82570 # Feet
+        9:  82566 # Wrists
+        10: 82568 # Hands
 
     # description=0 (Alliance) set=1976
     - name: Heritage of Gilneas

--- a/transmog/misc/racial.yml
+++ b/transmog/misc/racial.yml
@@ -182,7 +182,6 @@ groups:
   - Orc 3
   - Undead
   - Tauren
-  - Undead
   - Blood Elf
   - Goblin
   - Nightborne

--- a/transmog/misc/racial.yml
+++ b/transmog/misc/racial.yml
@@ -10,7 +10,6 @@ groups:
   - Dwarf
   - Night Elf
   - Gnome
-  - Night Elf
   - Worgen
   - Void Elf
   - Lightforged Draenei
@@ -97,19 +96,6 @@ groups:
         9:  39926 # Wrists
         10: 39922 # Hands
         16: 39927 # Back
-
-    # description=0 (Alliance)
-    - name: Heritage of the Kaldorei
-      wowheadSetId:
-      items:
-        1:  82569 # Head
-        3:  82571 # Shoulders
-        5:  82573 # Chest
-        6:  82572 # Waist
-        7:  82567 # Legs
-        8:  82570 # Feet
-        9:  82566 # Wrists
-        10: 82568 # Hands
 
     # description=0 (Alliance) set=1976
     - name: Heritage of Gilneas


### PR DESCRIPTION
### Description
* Adds Azerothian Archives to the reputation list
* Adds the Undead heritage armor
* Adds the Night Elf heritage armor

| Heritage armor | Reputation |
| --- | --- |
| <img src="https://github.com/ThingEngineering/wowthing-data/assets/19818239/3b558125-309d-4091-a385-7f3d837ef1f4" width="1000px" /> | <img src="https://github.com/ThingEngineering/wowthing-data/assets/19818239/0bc6dd06-d55e-436d-b75a-363bb0b2e600" width="1000px" /> |
