### PR TITLE
Shiny Pet Charms deprecated

### DIFF
--- a/_shared/vendor/06-legion/dalaran/draemus.yml
+++ b/_shared/vendor/06-legion/dalaran/draemus.yml
@@ -7,34 +7,34 @@ sells:
   - type: pet
     id: 1805 # Alarm-o-Bot
     costs:
-      1116415: 200 # Shiny Pet Charm
+      1163036: 200 # Polished Pet Charm
 
   - type: pet
     id: 1429 # Autumnal Sproutling
     costs:
-      1116415: 100 # Shiny Pet Charm
+      1163036: 100 # Polished Pet Charm
 
   - type: pet
     id: 1760 # Fel Piglet
     costs:
-      1116415: 200 # Shiny Pet Charm
+      1163036: 200 # Polished Pet Charm
 
   - type: pet
     id: 1715 # Nightwatch Swooper
     costs:
-      1116415: 100 # Shiny Pet Charm
+      1163036: 100 # Polished Pet Charm
 
   - type: pet
     id: 1755 # Plump Jelly
     costs:
-      1116415: 50 # Shiny Pet Charm
+      1163036: 50 # Polished Pet Charm
 
   - type: pet
     id: 1453 # River Calf
     costs:
-      1116415: 50 # Shiny Pet Charm
+      1163036: 50 # Polished Pet Charm
 
   - type: toy
     id: 140231 # Narcissa's Mirror
     costs:
-      1116415: 1000 # Shiny Pet Charm
+      1163036: 1000 # Polished Pet Charm

--- a/_shared/vendor/06-legion/dalaran/tiffy_trapspring.yml
+++ b/_shared/vendor/06-legion/dalaran/tiffy_trapspring.yml
@@ -7,34 +7,34 @@ sells:
   - type: pet
     id: 1577 # Bloodthorn Hatchling
     costs:
-      1116415: 50 # Shiny Pet Charm
+      1163036: 50 # Polished Pet Charm
 
   - type: pet
     id: 1588 # Dusty Sporewing
     costs:
-      1116415: 50 # Shiny Pet Charm
+      1163036: 50 # Polished Pet Charm
 
   - type: pet
     id: 1598 # Glowing Sporebat
     costs:
-      1116415: 100 # Shiny Pet Charm
+      1163036: 100 # Polished Pet Charm
 
   - type: pet
     id: 1661 # Lost Netherpup
     costs:
-      1116415: 200 # Shiny Pet Charm
+      1163036: 200 # Polished Pet Charm
 
   - type: toy
     id: 127707 # Indestructible Bone
     costs:
-      1116415: 50 # Shiny Pet Charm
+      1163036: 50 # Polished Pet Charm
 
   - type: toy
     id: 127696 # Magic Pet Mirror
     costs:
-      1116415: 500 # Shiny Pet Charm
+      1163036: 500 # Polished Pet Charm
 
   - type: toy
     id: 127695 # Spirit Wand
     costs:
-      1116415: 100 # Shiny Pet Charm
+      1163036: 100 # Polished Pet Charm


### PR DESCRIPTION
Replace Shiny Pet Charms with Polished Pet Charms 1:1