### PR TITLE
Add TWW Skyriding Race data

### DIFF
--- a/progress/dragon-racing/azj-kahet.yml
+++ b/progress/dragon-racing/azj-kahet.yml
@@ -1,0 +1,116 @@
+name: "Azj-Kahet"
+groups:
+
+- name: "City of Threads Twist"
+  icon: "achievement/19559"
+  iconText: "AK1"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2977
+        name: "Normal"
+        description: "83 78"
+
+      - id: 2983
+        name: "Advanced"
+        description: "77 74"
+
+      - id: 2989
+        name: "Reverse"
+        description: "77 74"
+
+- name: "Maddening Deep Dip"
+  icon: "achievement/19559"
+  iconText: "AK2"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2978
+        name: "Normal"
+        description: "63 58"
+
+      - id: 2984
+        name: "Advanced"
+        description: "57 54"
+
+      - id: 2990
+        name: "Reverse"
+        description: "59 56"
+
+- name: "The Weaver's Wing"
+  icon: "achievement/19559"
+  iconText: "AK3"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2979
+        name: "Normal"
+        description: "59 54"
+
+      - id: 2985
+        name: "Advanced"
+        description: "54 51"
+
+      - id: 2991
+        name: "Reverse"
+        description: "53 50"
+
+- name: "Rak-Ahat Rush"
+  icon: "achievement/19559"
+  iconText: "AK4"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2980
+        name: "Normal"
+        description: "75 70"
+
+      - id: 2986
+        name: "Advanced"
+        description: "69 66"
+
+      - id: 2992
+        name: "Reverse"
+        description: "69 66"
+
+- name: "Pit Plunge"
+  icon: "achievement/19559"
+  iconText: "AK5"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2981
+        name: "Normal"
+        description: "68 63"
+
+      - id: 2987
+        name: "Advanced"
+        description: "64 61"
+
+      - id: 2993
+        name: "Reverse"
+        description: "64 61"
+
+- name: "Siegehold Scuttle"
+  icon: "achievement/19559"
+  iconText: "AK6"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2982
+        name: "Normal"
+        description: "75 70"
+
+      - id: 2988
+        name: "Advanced"
+        description: "69 66"
+
+      - id: 2994
+        name: "Reverse"
+        description: "66 63"

--- a/progress/dragon-racing/hallowfall.yml
+++ b/progress/dragon-racing/hallowfall.yml
@@ -1,0 +1,116 @@
+name: "Hallowfall"
+groups:
+
+- name: "Dunelle's Detour"
+  icon: "achievement/20598"
+  iconText: "HF1"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2959
+        name: "Normal"
+        description: "65 70"
+
+      - id: 2965
+        name: "Advanced"
+        description: "59 62"
+
+      - id: 2971
+        name: "Reverse"
+        description: "61 64"
+
+- name: "Tenir's Traversal"
+  icon: "achievement/20598"
+  iconText: "HF2"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2960
+        name: "Normal"
+        description: "70 65"
+
+      - id: 2966
+        name: "Advanced"
+        description: "63 60"
+
+      - id: 2972
+        name: "Reverse"
+        description: "66 63"
+
+- name: "Light's Redoubt Descent"
+  icon: "achievement/20598"
+  iconText: "HF3"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2961
+        name: "Normal"
+        description: "68 63"
+
+      - id: 2967
+        name: "Advanced"
+        description: "65 62"
+
+      - id: 2973
+        name: "Reverse"
+        description: "65 62"
+
+- name: "Stillstone Slalom"
+  icon: "achievement/20598"
+  iconText: "HF4"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2962
+        name: "Normal"
+        description: "61 56"
+
+      - id: 2968
+        name: "Advanced"
+        description: "57 54"
+
+      - id: 2974
+        name: "Reverse"
+        description: "59 56"
+
+- name: "Mereldar Meander"
+  icon: "achievement/20598"
+  iconText: "HF5"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2963
+        name: "Normal"
+        description: "81 76"
+
+      - id: 2969
+        name: "Advanced"
+        description: "74 71"
+
+      - id: 2975
+        name: "Reverse"
+        description: "74 71"
+
+- name: "Velhan's Venture"
+  icon: "achievement/20598"
+  iconText: "HF6"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2964
+        name: "Normal"
+        description: "60 55"
+
+      - id: 2970
+        name: "Advanced"
+        description: "53 50"
+
+      - id: 2976
+        name: "Reverse"
+        description: "53 50"

--- a/progress/dragon-racing/isle_of_dorn.yml
+++ b/progress/dragon-racing/isle_of_dorn.yml
@@ -1,0 +1,116 @@
+name: "Isle of Dorn"
+groups:
+
+- name: "Dornogal Drift"
+  icon: "achievement/20118"
+  iconText: "IoD1"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2923
+        name: "Normal"
+        description: "53 48"
+
+      - id: 2929
+        name: "Advanced"
+        description: "46 43"
+
+      - id: 2935
+        name: "Reverse"
+        description: "46 43"
+
+- name: "Storm's Watch Survey"
+  icon: "achievement/20118"
+  iconText: "IoD2"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2924
+        name: "Normal"
+        description: "68 63"
+
+      - id: 2930
+        name: "Advanced"
+        description: "63 60"
+
+      - id: 2936
+        name: "Reverse"
+        description: "65 62"
+
+- name: "Basin Bypass"
+  icon: "achievement/20118"
+  iconText: "IoD3"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2925
+        name: "Normal"
+        description: "63 58"
+
+      - id: 2931
+        name: "Advanced"
+        description: "57 54"
+
+      - id: 2937
+        name: "Reverse"
+        description: "60 57"
+
+- name: "The Wold Ways"
+  icon: "achievement/20118"
+  iconText: "IoD4"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2926
+        name: "Normal"
+        description: "73 68"
+
+      - id: 2932
+        name: "Advanced"
+        description: "71 68"
+
+      - id: 2938
+        name: "Reverse"
+        description: "73 70"
+
+- name: "Thunderhead Trail"
+  icon: "achievement/20118"
+  iconText: "IoD5"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2927
+        name: "Normal"
+        description: "75 70"
+
+      - id: 2933
+        name: "Advanced"
+        description: "69 66"
+
+      - id: 2939
+        name: "Reverse"
+        description: "69 66"
+
+- name: "Orecreg's Doglegs"
+  icon: "achievement/20118"
+  iconText: "IoD6"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2928
+        name: "Normal"
+        description: "70 65"
+
+      - id: 2934
+        name: "Advanced"
+        description: "64 61"
+
+      - id: 2940
+        name: "Reverse"
+        description: "64 61"

--- a/progress/dragon-racing/ringing_deeps.yml
+++ b/progress/dragon-racing/ringing_deeps.yml
@@ -1,0 +1,116 @@
+name: "The Ringing Deeps"
+groups:
+
+- name: "Earthenworks Weave"
+  icon: "achievement/19560"
+  iconText: "RD1"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2941
+        name: "Normal"
+        description: "57 52"
+
+      - id: 2947
+        name: "Advanced"
+        description: "52 49"
+
+      - id: 2953
+        name: "Reverse"
+        description: "53 50"
+
+- name: "Ringing Deeps Ramble"
+  icon: "achievement/19560"
+  iconText: "RD2"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2942
+        name: "Normal"
+        description: "62 57"
+
+      - id: 2948
+        name: "Advanced"
+        description: "56 53"
+
+      - id: 2954
+        name: "Reverse"
+        description: "56 53"
+
+- name: "Chittering Concourse"
+  icon: "achievement/19560"
+  iconText: "RD3"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2943
+        name: "Normal"
+        description: "61 56"
+
+      - id: 2949
+        name: "Advanced"
+        description: "56 53"
+
+      - id: 2955
+        name: "Reverse"
+        description: "57 54"
+
+- name: "Cataract River Cruise"
+  icon: "achievement/19560"
+  iconText: "RD4"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2944
+        name: "Normal"
+        description: "65 60"
+
+      - id: 2950
+        name: "Advanced"
+        description: "61 58"
+
+      - id: 2956
+        name: "Reverse"
+        description: "60 57"
+
+- name: "Taelloch Twist"
+  icon: "achievement/19560"
+  iconText: "RD5"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2945
+        name: "Normal"
+        description: "52 47"
+
+      - id: 2951
+        name: "Advanced"
+        description: "46 43"
+
+      - id: 2957
+        name: "Reverse"
+        description: "47 44"
+
+- name: "Opportunity Point Amble"
+  icon: "achievement/19560"
+  iconText: "RD6"
+  lookup: none
+  type: dragon-racing
+  data:
+    0:
+      - id: 2946
+        name: "Normal"
+        description: "0 0"
+
+      - id: 2952
+        name: "Advanced"
+        description: "0 0"
+
+      - id: 2958
+        name: "Reverse"
+        description: "0 0"


### PR DESCRIPTION
Adds The War Within Skyriding Race data. Includes Isle of Dorn, The Ringing Deeps, Hallowfall, and Azj-Kahet data for Normal, Advanced and Reverse races.