### PR TITLE
Add Brewfest 2024 Homebrewer's Sampling Mantle

### DIFF
--- a/_shared/vendor/world-events/brewfest/alliance/belbi_quikswitch.yml
+++ b/_shared/vendor/world-events/brewfest/alliance/belbi_quikswitch.yml
@@ -61,6 +61,11 @@ sells:
       1037829: 200 # Brewfest Prize Token
 
   - type: transmog
+    id: 227795 # Homebrewer's Sampling Mantle [back]
+    costs:
+      1037829: 200 # Brewfest Prize Token
+
+  - type: transmog
     id: 209044 # Orange Brewfest Bulwark [shield]
     costs:
       1037829: 200 # Brewfest Prize Token

--- a/_shared/vendor/world-events/brewfest/horde/blix_fixwidget.yml
+++ b/_shared/vendor/world-events/brewfest/horde/blix_fixwidget.yml
@@ -61,6 +61,11 @@ sells:
       1037829: 200 # Brewfest Prize Token
 
   - type: transmog
+    id: 227795 # Homebrewer's Sampling Mantle [back]
+    costs:
+      1037829: 200 # Brewfest Prize Token
+
+  - type: transmog
     id: 209044 # Orange Brewfest Bulwark [shield]
     costs:
       1037829: 200 # Brewfest Prize Token


### PR DESCRIPTION
Add new Brewfest 2024 item [Homebrewer's Sampling Mantle backpiece](https://www.wowhead.com/item=227795/homebrewers-sampling-mantle)