### PR TITLE
Fix times for Ringing Deeps: Opportunity Point Amble

### DIFF
--- a/progress/skyriding-racing/ringing_deeps.yml
+++ b/progress/skyriding-racing/ringing_deeps.yml
@@ -105,12 +105,12 @@ groups:
     0:
       - id: 2946
         name: "Normal"
-        description: "0 0"
+        description: "82 77"
 
       - id: 2952
         name: "Advanced"
-        description: "0 0"
+        description: "74 71"
 
       - id: 2958
         name: "Reverse"
-        description: "0 0"
+        description: "75 72"


### PR DESCRIPTION
I just did all the Dragonriding/Skyriding races and noticed that this one wasn't showing progress correctly as the gold/silver times were set to 0s. This PR seeks to correct that.

![WoWScrnShot_122925_234712](https://github.com/user-attachments/assets/65888b95-8868-4a0b-b425-6f4ff3c3fd0b)

![WoWScrnShot_122925_235019](https://github.com/user-attachments/assets/2db2e1e5-733d-4f0e-8525-0244678f33d2)

![WoWScrnShot_122925_235216](https://github.com/user-attachments/assets/9b4d6ce9-4042-4982-bc3f-fc420f01428d)
